### PR TITLE
feat: add nullable method

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ WP Query Builder uses <code>PDO</code> for database queries. It has <strong>zero
 DB::create('querybuilder')
     ->column('ID')->bigInt()->unsigned()->autoIncrement()->primary()->required()
     ->column('name')->string(255)->required()
-    ->column('email')->string(255)->default('NULL')
+    ->column('email')->string(255)->nullable()
     ->index(['ID'])
     ->execute();
 

--- a/src/Api/CreateInterface.php
+++ b/src/Api/CreateInterface.php
@@ -4,41 +4,41 @@ namespace CodesVault\Howdyqb\Api;
 
 interface CreateInterface
 {
-    function column(string $column_name): self;
+    public function column(string $column_name): self;
 
-    function int(int $size = 255): self;
+    public function int(int $size = 255): self;
 
-    function bigInt(int $size = 255): self;
+    public function bigInt(int $size = 255): self;
 
-    function double(int $size = 255, int $d = 2): self;
+    public function double(int $size = 255, int $d = 2): self;
 
-    function boolean(): self;
+    public function boolean(): self;
 
-    function string(int $size = 255): self;
+    public function string(int $size = 255): self;
 
-    function text(int $size = 10000): self;
+    public function text(int $size = 10000): self;
 
-    function longText(int $size): self;
+    public function longText(int $size): self;
 
-    function required(): self;
+    public function required(): self;
 
-	function nullable(): self;
+    public function nullable(): self;
 
-    function primary($columns = []): self;
+    public function primary($columns = []): self;
 
-    function index(array $columns): self;
+    public function index(array $columns): self;
 
-    function date(): self;
+    public function date(): self;
 
-    function dateTime(): self;
+    public function dateTime(): self;
 
-    function unsigned(): self;
+    public function unsigned(): self;
 
-    function autoIncrement(): self;
+    public function autoIncrement(): self;
 
-    function default($value): self;
+    public function default($value): self;
 
-    function foreignKey(string $column, string $reference_table, string $reference_column): self;
+    public function foreignKey(string $column, string $reference_table, string $reference_column): self;
 
-    function execute();
+    public function execute();
 }

--- a/src/Api/CreateInterface.php
+++ b/src/Api/CreateInterface.php
@@ -22,6 +22,8 @@ interface CreateInterface
 
     function required(): self;
 
+	function nullable(): self;
+
     function primary($columns = []): self;
 
     function index(array $columns): self;

--- a/src/Api/DeleteInterface.php
+++ b/src/Api/DeleteInterface.php
@@ -4,15 +4,15 @@ namespace CodesVault\Howdyqb\Api;
 
 interface DeleteInterface
 {
-    function where($column, string $operator = null, string $value = null): self;
+    public function where($column, string $operator = null, string $value = null): self;
 
-    function andWhere(string $column, string $operator = null, string $value = null): self;
+    public function andWhere(string $column, string $operator = null, string $value = null): self;
 
-    function orWhere(string $column, string $operator = null, string $value = null): self;
+    public function orWhere(string $column, string $operator = null, string $value = null): self;
 
-    function drop();
+    public function drop();
 
-    function dropIfExists();
+    public function dropIfExists();
 
-    function execute();
+    public function execute();
 }

--- a/src/Api/DropInterface.php
+++ b/src/Api/DropInterface.php
@@ -4,7 +4,7 @@ namespace CodesVault\Howdyqb\Api;
 
 interface DropInterface
 {
-    function drop();
+    public function drop();
 
-    function dropIfExists();
+    public function dropIfExists();
 }

--- a/src/Api/SelectInterface.php
+++ b/src/Api/SelectInterface.php
@@ -4,13 +4,13 @@ namespace CodesVault\Howdyqb\Api;
 
 interface SelectInterface
 {
-    function distinct(): self;
+    public function distinct(): self;
 
-    function columns(...$columns): self;
+    public function columns(...$columns): self;
 
-    function alias(string $name): self;
+    public function alias(string $name): self;
 
-    function from(string $table_name): self;
+    public function from(string $table_name): self;
 
     /**
      * JOIN table(s) ON condition of
@@ -22,7 +22,7 @@ interface SelectInterface
      *
      * @return CodesVault\Howdyqb\Api\SelectInterface
      */
-    function join($table_name, string $col1 = null, string $col2 = null): self;
+    public function join($table_name, string $col1 = null, string $col2 = null): self;
 
     /**
      * INNER JOIN table(s) ON condition of
@@ -34,7 +34,7 @@ interface SelectInterface
      *
      * @return CodesVault\Howdyqb\Api\SelectInterface
      */
-    function innerJoin($table_name, string $col1 = null, string $col2 = null): self;
+    public function innerJoin($table_name, string $col1 = null, string $col2 = null): self;
 
     /**
      * LEFT JOIN table(s) ON condition of
@@ -46,7 +46,7 @@ interface SelectInterface
      *
      * @return CodesVault\Howdyqb\Api\SelectInterface
      */
-    function leftJoin($table_name, string $col1 = null, string $col2 = null): self;
+    public function leftJoin($table_name, string $col1 = null, string $col2 = null): self;
 
     /**
      * RIGHT JOIN table(s) ON condition of
@@ -58,31 +58,31 @@ interface SelectInterface
      *
      * @return CodesVault\Howdyqb\Api\SelectInterface
      */
-    function rightJoin($table_name, string $col1 = null, string $col2 = null): self;
+    public function rightJoin($table_name, string $col1 = null, string $col2 = null): self;
 
-    function where($column, ?string $operator = null, ?string $value = null): self;
+    public function where($column, ?string $operator = null, ?string $value = null): self;
 
-    function andWhere(string $column, ?string $operator, ?string $value): self;
+    public function andWhere(string $column, ?string $operator, ?string $value): self;
 
-    function orWhere(string $column, ?string $operator, ?string $value): self;
+    public function orWhere(string $column, ?string $operator, ?string $value): self;
 
-    function whereNot(string $column, ?string $operator, ?string $value): self;
+    public function whereNot(string $column, ?string $operator, ?string $value): self;
 
-    function andNot(string $column, ?string $operator, ?string $value): self;
+    public function andNot(string $column, ?string $operator, ?string $value): self;
 
-    function whereIn(string $column, ...$value): self;
+    public function whereIn(string $column, ...$value): self;
 
-    function orderBy($column, string $sort): self;
+    public function orderBy($column, string $sort): self;
 
-    function groupBy($column): self;
+    public function groupBy($column): self;
 
-    function limit(int $count): self;
+    public function limit(int $count): self;
 
-    function offset(int $count): self;
+    public function offset(int $count): self;
 
-    function count(string $column, string $alias = ''): self;
+    public function count(string $column, string $alias = ''): self;
 
-    function raw(string $sql): self;
+    public function raw(string $sql): self;
 
-    function get();
+    public function get();
 }

--- a/src/Api/UpdateInterface.php
+++ b/src/Api/UpdateInterface.php
@@ -4,11 +4,11 @@ namespace CodesVault\Howdyqb\Api;
 
 interface UpdateInterface
 {
-    function where($column, string $operator = null, string $value = null): self;
+    public function where($column, string $operator = null, string $value = null): self;
 
-    function andWhere(string $column, string $operator = null, string $value = null): self;
+    public function andWhere(string $column, string $operator = null, string $value = null): self;
 
-    function orWhere(string $column, string $operator = null, string $value = null): self;
+    public function orWhere(string $column, string $operator = null, string $value = null): self;
 
-    function execute();
+    public function execute();
 }

--- a/src/Statement/Create.php
+++ b/src/Statement/Create.php
@@ -81,6 +81,11 @@ class Create implements CreateInterface
         return $this;
     }
 
+    public function nullable(): self
+    {
+        return $this->default('NULL');
+    }
+
     public function primary($columns = []): self
     {
         if (! empty($columns)) {

--- a/tests/CreateTest.php
+++ b/tests/CreateTest.php
@@ -7,12 +7,11 @@ use CodesVault\Howdyqb\Tests\Statement\CreateApi;
 
 class CreateTest extends TestCase
 {
-    public function testCreateTable()
+    public function test_create_table()
     {
-        $sql = "CREATE TABLE wp_test (ID BIGINT(255) UNSIGNED AUTO_INCREMENT PRIMARY KEY NOT NULL, name VARCHAR(255) NOT NULL, email VARCHAR(255) DEFAULT 'nil', INDEX (ID) )";
+        $sql = "CREATE TABLE wp_test (ID BIGINT(255) UNSIGNED AUTO_INCREMENT PRIMARY KEY NOT NULL, name VARCHAR(255) NOT NULL, email VARCHAR(255) DEFAULT 'nil', INDEX (ID))";
 
-        $query =
-            CreateApi::create('test')
+        $query = CreateApi::create('test')
             ->column('ID')->bigInt()->unsigned()->autoIncrement()->primary()->required()
             ->column('name')->string(255)->required()
             ->column('email')->string(255)->default('nil')
@@ -20,5 +19,23 @@ class CreateTest extends TestCase
             ->getSql();
 
         $this->assertSame($sql, $query);
+    }
+
+    public function test_nullable()
+    {
+        $sql = "CREATE TABLE wp_test (secondary_email VARCHAR(255) DEFAULT 'NULL')";
+
+        $query = CreateApi::create('test')
+            ->column('secondary_email')->string(255)->default('NULL')
+            ->getSql();
+
+        $this->assertSame($sql, $query);
+
+        $query = CreateApi::create('test')
+            ->column('secondary_email')->string(255)->nullable()
+            ->getSql();
+
+        $this->assertSame($sql, $query);
+
     }
 }


### PR DESCRIPTION
This PR add the method `nullable()` for table create statements.

example:

```diff
DB::create('user')
-    ->column('secondary_email')->string(255)->default('NULL')
+    ->column('secondary_email')->string(255)->nullable()
    ->execute();
```