### PR TITLE
fix: Spelling Mistake for Composer installation fixed

### DIFF
--- a/doc/pages/documentation/getting-started.mdx
+++ b/doc/pages/documentation/getting-started.mdx
@@ -1,7 +1,7 @@
 # Getting Started
 
 ## Installation
-Install the library using composer `composer require codesvault/howdy_qb`.
+Install the library using composer `composer require codesvault/howdy-qb`.
 
 ## Database connection
 It connects to the WordPress database **automatically**.


### PR DESCRIPTION
This PR solved the issue https://github.com/CodesVault/howdy_qb/issues/23 as I created before
1. Solved spelling mistake for composer documentation