### PR TITLE
fix #27

### DIFF
--- a/src/SqlGenerator.php
+++ b/src/SqlGenerator.php
@@ -46,7 +46,7 @@ class SqlGenerator
 
             if (is_array($expression)) {
                 foreach ($expression as $name => $column) {
-                    $expression[$name] = $name . ' ' . implode(' ', $column);
+                    $expression[$name] = '`'. $name . '` ' . implode(' ', $column);
                 }
                 $query .= implode(', ', $expression);
             } else {


### PR DESCRIPTION
Fix table column naming with the preserved word or SQL keyword