### PR TITLE
Fix/multiple operator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,5 @@ dist
 
 # TernJS port file
 .tern-port
+
+.gityai

--- a/src/Api/CreateInterface.php
+++ b/src/Api/CreateInterface.php
@@ -44,7 +44,7 @@ interface CreateInterface
 
 	public function enum(array $allowed): self;
 
-    public function foreignKey(string $column, string $ref_table_column, string $on_delete = null): self;
+    public function foreignKey(string $column, string $ref_table_column, ?string $on_delete = null): self;
 
     public function onDelete(string $action): self;
 

--- a/src/Api/DeleteInterface.php
+++ b/src/Api/DeleteInterface.php
@@ -4,11 +4,11 @@ namespace CodesVault\Howdyqb\Api;
 
 interface DeleteInterface
 {
-    public function where($column, string $operator = null, string $value = null): self;
+    public function where($column, ?string $operator = null, ?string $value = null): self;
 
-    public function andWhere(string $column, string $operator = null, string $value = null): self;
+    public function andWhere(string $column, ?string $operator = null, ?string $value = null): self;
 
-    public function orWhere(string $column, string $operator = null, string $value = null): self;
+    public function orWhere(string $column, ?string $operator = null, ?string $value = null): self;
 
     public function drop();
 

--- a/src/Api/SelectInterface.php
+++ b/src/Api/SelectInterface.php
@@ -22,7 +22,7 @@ interface SelectInterface
      *
      * @return CodesVault\Howdyqb\Api\SelectInterface
      */
-    public function join($table_name, string $col1 = null, string $col2 = null): self;
+    public function join($table_name, ?string $col1 = null, ?string $col2 = null): self;
 
     /**
      * INNER JOIN table(s) ON condition of
@@ -34,7 +34,7 @@ interface SelectInterface
      *
      * @return CodesVault\Howdyqb\Api\SelectInterface
      */
-    public function innerJoin($table_name, string $col1 = null, string $col2 = null): self;
+    public function innerJoin($table_name, ?string $col1 = null, ?string $col2 = null): self;
 
     /**
      * LEFT JOIN table(s) ON condition of
@@ -46,7 +46,7 @@ interface SelectInterface
      *
      * @return CodesVault\Howdyqb\Api\SelectInterface
      */
-    public function leftJoin($table_name, string $col1 = null, string $col2 = null): self;
+    public function leftJoin($table_name, ?string $col1 = null, ?string $col2 = null): self;
 
     /**
      * RIGHT JOIN table(s) ON condition of
@@ -58,7 +58,7 @@ interface SelectInterface
      *
      * @return CodesVault\Howdyqb\Api\SelectInterface
      */
-    public function rightJoin($table_name, string $col1 = null, string $col2 = null): self;
+    public function rightJoin($table_name, ?string $col1 = null, ?string $col2 = null): self;
 
     public function where($column, ?string $operator = null, ?string $value = null): self;
 

--- a/src/Api/UpdateInterface.php
+++ b/src/Api/UpdateInterface.php
@@ -4,11 +4,11 @@ namespace CodesVault\Howdyqb\Api;
 
 interface UpdateInterface
 {
-    public function where($column, string $operator = null, string $value = null): self;
+    public function where($column, ?string $operator = null, ?string $value = null): self;
 
-    public function andWhere(string $column, string $operator = null, string $value = null): self;
+    public function andWhere(string $column, ?string $operator = null, ?string $value = null): self;
 
-    public function orWhere(string $column, string $operator = null, string $value = null): self;
+    public function orWhere(string $column, ?string $operator = null, ?string $value = null): self;
 
     function getSql();
 

--- a/src/SqlGenerator.php
+++ b/src/SqlGenerator.php
@@ -12,6 +12,9 @@ class SqlGenerator
         }
         foreach ($sql as $key => $value) {
             if ($key == 'start') continue;
+			if (is_array($value)) {
+				$value = trim(implode(' ', $value));
+			}
             $query .= $value . ' ';
         }
         return trim($query);

--- a/src/Statement/Create.php
+++ b/src/Statement/Create.php
@@ -156,7 +156,7 @@ class Create implements CreateInterface
         return $this;
     }
 
-    public function foreignKey(string $column, string $ref_table_column, string $on_delete = null): self
+    public function foreignKey(string $column, string $ref_table_column, ?string $on_delete = null): self
     {
 		$ref_table_column = explode('.', $ref_table_column);
         $table_name = Utilities::get_db_configs()->prefix . $ref_table_column[0];

--- a/src/Statement/Delete.php
+++ b/src/Statement/Delete.php
@@ -25,7 +25,7 @@ class Delete implements DeleteInterface
         $this->sql['start'] = 'DELETE FROM ' . $this->table_name;
     }
 
-    public function where($column, string $operator = null, string $value = null): self
+    public function where($column, ?string $operator = null, ?string $value = null): self
     {
         if ( is_callable( $column ) ) {
             call_user_func( $column, $this );
@@ -36,14 +36,14 @@ class Delete implements DeleteInterface
         return $this;
     }
 
-    public function andWhere(string $column, string $operator = null, string $value = null): self
+    public function andWhere(string $column, ?string $operator = null, ?string $value = null): self
     {
         $this->sql['andWhere'] = 'AND ' . $column . ' ' . $operator . ' ' . Utilities::get_placeholder($this->db, $value);
         $this->params[] = $value;
         return $this;
     }
 
-    public function orWhere(string $column, string $operator = null, string $value = null): self
+    public function orWhere(string $column, ?string $operator = null, ?string $value = null): self
     {
         $this->sql['orWhere'] = 'OR ' . $column . ' ' . $operator . ' ' . Utilities::get_placeholder($this->db, $value);
         $this->params[] = $value;

--- a/src/Statement/Select.php
+++ b/src/Statement/Select.php
@@ -82,35 +82,35 @@ class Select implements SelectInterface
 
     public function andWhere(string $column, string $operator = null, $value = null): self
     {
-        $this->sql['andWhere'] = 'AND ' . $column . ' ' . $operator . ' ' . Utilities::get_placeholder($this->db, $value);
+        $this->sql['andWhere'][] = 'AND ' . $column . ' ' . $operator . ' ' . Utilities::get_placeholder($this->db, $value);
         $this->params[] = $value;
         return $this;
     }
 
     public function orWhere(string $column, string $operator = null, $value = null): self
     {
-        $this->sql['orWhere'] = 'OR ' . $column . ' ' . $operator . ' ' . Utilities::get_placeholder($this->db, $value);
+        $this->sql['orWhere'][] = 'OR ' . $column . ' ' . $operator . ' ' . Utilities::get_placeholder($this->db, $value);
         $this->params[] = $value;
         return $this;
     }
 
     public function whereNot(string $column, string $operator = null, $value = null): self
     {
-        $this->sql['whereNot'] = 'WHERE NOT ' . $column . ' ' . $operator . ' ' . Utilities::get_placeholder($this->db, $value);
+        $this->sql['whereNot'][] = 'WHERE NOT ' . $column . ' ' . $operator . ' ' . Utilities::get_placeholder($this->db, $value);
         $this->params[] = $value;
         return $this;
     }
 
     public function andNot(string $column, string $operator = null, $value = null): self
     {
-        $this->sql['andNot'] = 'AND NOT ' . $column . ' ' . $operator . ' ' . Utilities::get_placeholder($this->db, $value);
+        $this->sql['andNot'][] = 'AND NOT ' . $column . ' ' . $operator . ' ' . Utilities::get_placeholder($this->db, $value);
         $this->params[] = $value;
         return $this;
     }
 
     public function whereIn(string $column, ...$value): self
     {
-        $this->sql['whereIn'] = 'WHERE ' . $column . ' IN (' . implode( ', ', $value ) . ')';
+        $this->sql['whereIn'][] = 'WHERE ' . $column . ' IN (' . implode( ', ', $value ) . ')';
         return $this;
     }
 

--- a/src/Statement/Select.php
+++ b/src/Statement/Select.php
@@ -80,28 +80,28 @@ class Select implements SelectInterface
         return $this;
     }
 
-    public function andWhere(string $column, string $operator = null, $value = null): self
+    public function andWhere(string $column, ?string $operator = null, $value = null): self
     {
         $this->sql['andWhere'][] = 'AND ' . $column . ' ' . $operator . ' ' . Utilities::get_placeholder($this->db, $value);
         $this->params[] = $value;
         return $this;
     }
 
-    public function orWhere(string $column, string $operator = null, $value = null): self
+    public function orWhere(string $column, ?string $operator = null, $value = null): self
     {
         $this->sql['orWhere'][] = 'OR ' . $column . ' ' . $operator . ' ' . Utilities::get_placeholder($this->db, $value);
         $this->params[] = $value;
         return $this;
     }
 
-    public function whereNot(string $column, string $operator = null, $value = null): self
+    public function whereNot(string $column, ?string $operator = null, $value = null): self
     {
         $this->sql['whereNot'][] = 'WHERE NOT ' . $column . ' ' . $operator . ' ' . Utilities::get_placeholder($this->db, $value);
         $this->params[] = $value;
         return $this;
     }
 
-    public function andNot(string $column, string $operator = null, $value = null): self
+    public function andNot(string $column, ?string $operator = null, $value = null): self
     {
         $this->sql['andNot'][] = 'AND NOT ' . $column . ' ' . $operator . ' ' . Utilities::get_placeholder($this->db, $value);
         $this->params[] = $value;
@@ -147,7 +147,7 @@ class Select implements SelectInterface
         return $this;
     }
 
-    private function setJoin($table_name, string $col1 = null, string $col2 = null, string $joinType = 'JOIN'): self
+    private function setJoin($table_name, ?string $col1 = null, ?string $col2 = null, string $joinType = 'JOIN'): self
     {
         $table_names = [];
         if (is_array($table_name)) {
@@ -172,22 +172,22 @@ class Select implements SelectInterface
         return $this;
     }
 
-    public function join($table_name, string $col1 = null, string $col2 = null): self
+    public function join($table_name, ?string $col1 = null, ?string $col2 = null): self
     {
         return $this->setJoin($table_name, $col1, $col2);
     }
 
-    public function innerJoin($table_name, string $col1 = null, string $col2 = null): self
+    public function innerJoin($table_name, ?string $col1 = null, ?string $col2 = null): self
     {
         return $this->setJoin($table_name, $col1, $col2, 'INNER JOIN');
     }
 
-    public function leftJoin($table_name, string $col1 = null, string $col2 = null): self
+    public function leftJoin($table_name, ?string $col1 = null, ?string $col2 = null): self
     {
         return $this->setJoin($table_name, $col1, $col2, 'LEFT JOIN');
     }
 
-    public function rightJoin($table_name, string $col1 = null, string $col2 = null): self
+    public function rightJoin($table_name, ?string $col1 = null, ?string $col2 = null): self
     {
         return $this->setJoin($table_name, $col1, $col2, 'RIGHT JOIN');
     }

--- a/src/Statement/Update.php
+++ b/src/Statement/Update.php
@@ -89,7 +89,7 @@ class Update implements UpdateInterface
         return 'SET ' . implode(', ', $columns);
     }
 
-    public function where($column, string $operator = null, $value = null): self
+    public function where($column, ?string $operator = null, $value = null): self
     {
         if ( is_callable( $column ) ) {
             call_user_func( $column, $this );
@@ -100,14 +100,14 @@ class Update implements UpdateInterface
         return $this;
     }
 
-    public function andWhere(string $column, string $operator = null, $value = null): self
+    public function andWhere(string $column, ?string $operator = null, $value = null): self
     {
         $this->sql['andWhere'] = 'AND ' . $column . ' ' . $operator . ' ' . Utilities::get_placeholder($this->db, $value);
         $this->params[] = $value;
         return $this;
     }
 
-    public function orWhere(string $column, string $operator = null, $value = null): self
+    public function orWhere(string $column, ?string $operator = null, $value = null): self
     {
         $this->sql['orWhere'] = 'OR ' . $column . ' ' . $operator . ' ' . Utilities::get_placeholder($this->db, $value);
         $this->params[] = $value;


### PR DESCRIPTION
# feat: Query Builder Enhancements: Chained WHERE Clauses & Nullable Type Hints

**Issue:** #38 

## Context

This Pull Request introduces significant enhancements to the query builder, focusing on improving both its functionality and type safety. It enables more flexible SQL query construction by allowing multiple `WHERE` clauses of the same type to be chained, and refactors method signatures with nullable type hints for better code clarity and robustness.

## Description

This PR significantly upgrades the query builder's capabilities and internal consistency.

Firstly, it introduces the ability to chain multiple `WHERE` clauses of the same logical type (e.g., `andWhere`, `orWhere`, `whereNot`, `andNot`, `whereIn`) within a single query. Previously, calling these methods repeatedly would overwrite prior conditions, effectively limiting a query to only one clause of each type. The internal SQL generation logic has been updated to store these conditions as arrays, which are then correctly concatenated by the `SqlGenerator` into the final SQL string. This allows for the construction of much more flexible and sophisticated queries, enabling developers to express complex conditions with ease.

Secondly, this PR refactors various method parameters by adding explicit nullable type hints (e.g., `?string`). For parameters that have a default value of `null`, this change explicitly communicates that `null` is an accepted value alongside their specified type. This improves code clarity, enhances the API contract for callers, and allows static analysis tools to better validate type usage, preventing potential runtime errors related to unexpected null values. This refactoring leverages PHP 7.1+ features for stronger type safety without altering the functional behavior of the methods.

## Changes in the codebase

*   **`src/Statement/Select.php`**:
    *   Modified `andWhere`, `orWhere`, `whereNot`, `andNot`, and `whereIn` methods to append generated SQL conditions to an array (`$this->sql['key'][]`) instead of directly assigning a string, enabling the chaining of multiple conditions.
    *   Updated method signatures for `andWhere`, `orWhere`, `whereNot`, `andNot`, `setJoin` (private), `join`, `innerJoin`, `leftJoin`, and `rightJoin` to include nullable type hints (`?string`).
*   **`src/SqlGenerator.php`**:
    *   Updated the `generate` method to correctly handle array values within the `$sql` property. If a `$value` is an array, its elements are `implode`d with a space and `trim`med before being appended to the final query string, ensuring chained conditions are properly joined.
*   **`src/Api/CreateInterface.php`**: Updated `foreignKey` method signature with nullable type hints.
*   **`src/Api/DeleteInterface.php`**: Updated `where`, `andWhere`, and `orWhere` method signatures with nullable type hints.
*   **`src/Api/SelectInterface.php`**: Updated `join`, `innerJoin`, `leftJoin`, and `rightJoin` method signatures with nullable type hints.
*   **`src/Api/UpdateInterface.php`**: Updated `where`, `andWhere`, and `orWhere` method signatures with nullable type hints.
*   **`src/Statement/Create.php`**: Updated `foreignKey` method implementation with nullable type hints.
*   **`src/Statement/Delete.php`**: Updated `where`, `andWhere`, and `orWhere` method implementations with nullable type hints.
*   **`src/Statement/Update.php`**: Updated `where`, `andWhere`, and `orWhere` method implementations with nullable type hints.
*   **`.gitignore`**: Added `.gityai` to the ignore list, preventing specific development-related files from being committed.
